### PR TITLE
Do not clear down test data as Jenkins runs both nodes at the same ti…

### DIFF
--- a/src/main/java/uk/gov/ea/datareturns/domain/jpa/service/TestDataInitialization.java
+++ b/src/main/java/uk/gov/ea/datareturns/domain/jpa/service/TestDataInitialization.java
@@ -60,10 +60,6 @@ public class TestDataInitialization {
     public void setUpTestData() {
         LOGGER.info("Test data initialization...");
 
-        // Remove any test data still persisted
-        // probably due to an ungraceful termination
-        tearDownTestData();
-
         // Add in the test data
         try {
             Site site2 = new Site();
@@ -90,8 +86,8 @@ public class TestDataInitialization {
             uniqueIdentifierDao.add(uniqueIdentifier1);
             uniqueIdentifierAliasDao.add(uniqueIdentifierAlias);
 
-        } catch (Exception e) {
-            LOGGER.warn("Error adding test data: " + e.getMessage());
+        } catch (Throwable e) {
+            LOGGER.warn("Cannot add test data: " + e.getMessage());
         }
 
         search.initialize();
@@ -142,7 +138,7 @@ public class TestDataInitialization {
             }
 
             LOGGER.info(ctr + " records removed");
-        } catch (Exception e) {
+        } catch (Throwable e) {
             LOGGER.info("Cannot remove test data: " + e.getMessage());
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,7 @@ logging:
     
     # Database
     org.hibernate: WARN
+    org.hibernate.engine.jdbc.spi.SqlExceptionHelper: OFF
     net.sf.ehcache: WARN
     liquibase: INFO
     


### PR DESCRIPTION
…me and there is a danger of interleaving.

Surpress error messages produced by SqlExceptionHelper. They does not appear to be being converted to a spring DataAccessException. This warrants further investigation but fixing quick and dirty for now